### PR TITLE
Directionalfix

### DIFF
--- a/analyzePriming.m
+++ b/analyzePriming.m
@@ -66,10 +66,9 @@ for i_e=1:length(exp_names)
         find(exp_ss==i_s)/length(exp_ss)
         
         subj_data = exp_data(exp_data.subNum==i_s,:);
-        
-        x = subj_data.x;
+        [y_str, ord_y] = sort(subj_data.(params.predict));
 
-        y_str = flip(sort(subj_data.(params.predict)));
+        x = subj_data.x(ord_y);
         y = strcmp(y_str,y_str{1});
         
         k = min(sum(y==0),sum(y==1));

--- a/analyzePriming.m
+++ b/analyzePriming.m
@@ -69,7 +69,7 @@ for i_e=1:length(exp_names)
         
         x = subj_data.x;
 
-        y_str = sort(subj_data.(params.predict));
+        y_str = flip(sort(subj_data.(params.predict)));
         y = strcmp(y_str,y_str{1});
         
         k = min(sum(y==0),sum(y==1));


### PR DESCRIPTION
Sorting y without sorting x according to the same order ruined the alignment between labels RTs.
I now sort x according to the order of the sorted y labels.  